### PR TITLE
Add support for node.js crypto.Hash style interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ The checksum is returned as a 32bit integer, but you can easily convert it to a 
 
 	var hex = adler32.sum(data).toString(16);
 
+## `crypto` Integration
+
+adler32 supports integration with the [node.js crypto module](http://nodejs.org/api/crypto.html#crypto_crypto_createhash_algorithm).
+To use, somewhere at the start of your application you should call `register()`.
+After this you can create hashes via `crypto.creashHash()`:
+
+    adler32.register();
+    var hash = crypto.createHash('adler32');
+	hash.update(data);
+	console.log(hash.digest('hex'));
+
+You can also create hash objects via the Hash constructor:
+
+    var hash = new adler32.Hash();
+
 ## Caveats
 
 Using a rolling window larger than 35,184,372,088,832 (32TB) may cause unexpected results due to integer overflows.

--- a/index.js
+++ b/index.js
@@ -62,3 +62,41 @@ exports.roll = function(sum, length, oldByte, newByte)
 
 	return ((b << 16) | a) >>> 0;
 };
+
+// Provides a node.js Hash style interface for adler32: http://nodejs.org/api/crypto.html#crypto_class_hash
+var Hash = exports.Hash = function()
+{
+	this.adler = 1;
+	this.done = false;
+};
+
+Hash.prototype.update = function(data, encoding)
+{
+	if (this.done) throw new Error("Cannot call update() after calling digest()");
+
+	if (!(data instanceof Buffer))
+	{
+		if (encoding == null) {
+			data = new Buffer(data, 'binary');
+		}
+		else
+		{
+			data = new Buffer(data, encoding);
+		}
+	}
+
+    return this.adler = exports.sum(data, this.adler);
+};
+
+Hash.prototype.digest = function(encoding)
+{
+ 	if (encoding == null) {
+		encoding = 'binary';
+	}
+
+	this.done = true;
+
+	var answer = new Buffer(4);
+	answer.writeUInt32BE(this.adler, 0);
+	return answer.toString(encoding);
+};

--- a/index.js
+++ b/index.js
@@ -63,6 +63,42 @@ exports.roll = function(sum, length, oldByte, newByte)
 	return ((b << 16) | a) >>> 0;
 };
 
+var registered = false;
+
+exports.register = function()
+{
+	if(registered) return;
+	registered = true;
+
+    var crypto = require('crypto');
+	if(crypto.getHashes().indexOf('adler32') != -1)
+	{
+		console.log("WARNING: crypto module already supports adler32 - not registering")
+	}
+	else
+	{
+		var originalGetHashes = crypto.getHashes;
+		var originalCreateHash = crypto.createHash;
+
+		crypto.getHashes = function()
+		{
+			return originalGetHashes.call(crypto).concat(['adler32'])
+		};
+
+		crypto.createHash = function(hash)
+		{
+			if(hash === 'adler32')
+			{
+				return new Hash();
+			}
+			else
+			{
+				return originalCreateHash.call(crypto, hash);
+			}
+		};
+	}
+};
+
 // Provides a node.js Hash style interface for adler32: http://nodejs.org/api/crypto.html#crypto_class_hash
 var Hash = exports.Hash = function()
 {

--- a/test.js
+++ b/test.js
@@ -97,6 +97,27 @@ describe('Adler32', function() {
 			}).should.throw();
 		});
 	});
+
+	describe('.register()', function () {
+		var crypto = require('crypto');
+		Adler32.register();
+		it('should make it so crypto.getHashes() contains adler32', function () {
+			crypto.getHashes().indexOf('adler32').should.not.equal(-1);
+		});
+		it('should make it so crypto.createHash() works for adler32', function () {
+			hash = crypto.createHash('adler32');
+			should.exist(hash);
+			hash.update('Wikipedia');
+			hash.digest('hex').toLowerCase().should.be.exactly('11e60398');
+		});
+		it('should not remove other crypto hashes', function () {
+			crypto.getHashes().indexOf('sha256').should.not.equal(-1);
+			hash = crypto.createHash('sha256');
+			should.exist(hash);
+			hash.update('Wikipedia');
+			hash.digest('hex');
+		});
+	});
 });
 
 function rollTest(chunkSize)

--- a/test.js
+++ b/test.js
@@ -71,6 +71,32 @@ describe('Adler32', function() {
 			rollTest(16384);
 		});
 	});
+
+	describe('.Hash', function () {
+		it('should hash a string', function() {
+			// Example taken from http://en.wikipedia.org/wiki/Adler-32.
+			hash = new Adler32.Hash();
+			hash.update('Wikipedia');
+			hash.digest('hex').toLowerCase().should.be.exactly('11e60398');
+		});
+
+		it('should hash a string in parts', function() {
+			hash = new Adler32.Hash();
+			hash.update('Wiki');
+			hash.update('pedia');
+			hash.digest('hex').toLowerCase().should.be.exactly('11e60398');
+		});
+
+		it('should not let you call update() after you call digest()', function() {
+			// Example taken from http://en.wikipedia.org/wiki/Adler-32.
+			hash = new Adler32.Hash();
+			hash.update('Wikipedia');
+			hash.digest('hex');
+			(function() {
+				hash.update('Moar!');
+			}).should.throw();
+		});
+	});
 });
 
 function rollTest(chunkSize)


### PR DESCRIPTION
This PR adds support for [node.js crypto.Hash](http://nodejs.org/api/crypto.html#crypto_class_hash) style interface:

``` javascript
hash = new Adler32.Hash();
hash.update('Wikipedia');
hash.digest('hex'); // returns '11e60398'
```

Handy if you have some existing code that uses the existing crypto infrastructure and you want to adapt it to use adler32 with a minimum of fuss.

Quite unrelated to this PR, but very nice implementation of adler32.  I wrote something like this about a year ago, and only got around to cleaning it up and [releasing it](https://github.com/jwalton/adler32-js) today, but yours is about five times as fast as mine.  :)
